### PR TITLE
update PYTHONPATH

### DIFF
--- a/CI/Dockerfile
+++ b/CI/Dockerfile
@@ -80,6 +80,8 @@ RUN /root/etc/CI/docker/build_hdf5.sh
 
 FROM hdf5 AS moab
 
+ENV PYTHONPATH=/root/build_dir/moab/bld/pymoab/lib/python3.6/site-packages
+
 # Set MOAB env variable
 ENV moab_build_dir=${build_dir}/moab
 ENV moab_install_dir=${install_dir}/moab


### PR DESCRIPTION
This allows CI to work.
As I stated on Slack the problem come from the local install of pyMOAB for the test purpose (`-e` option) that want to install pyMOAB in a folder that is not in the `PYTHONPATH`