### PR TITLE
Use multistage docker build action

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -50,7 +50,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-
       - name: Installing Dependencies in Docker image
         uses: firehed/multistage-docker-build-action@v1
         with:
@@ -61,23 +60,6 @@ jobs:
           tag-latest-on-default: false
           dockerfile: CI/Dockerfile
           build-args: OWNER=${{ github.repository_owner }}, TAG=ci_testing, UBUNTU_VERSION=${{ matrix.ubuntu_versions }}, COMPILER=${{ matrix.compiler }}, HDF5=${{ matrix.hdf5_versions }}, MOAB=${{ matrix.moab_versions }}, build_mw_reg_tests=ON
-        
-      # - name: Installing Dependencies in Docker image
-      #   uses: docker/build-push-action@v3
-      #   with:
-      #     file: CI/Dockerfile
-      #     target: moab
-      #     context: .
-      #     push: true
-      #     build-args: |
-      #       OWNER=${{ github.repository_owner }}
-      #       TAG=ci_testing
-      #       UBUNTU_VERSION=${{ matrix.ubuntu_versions }}
-      #       COMPILER=${{ matrix.compiler }}
-      #       HDF5=${{ matrix.hdf5_versions }}
-      #       MOAB=${{ matrix.moab_versions }}
-      #       build_mw_reg_tests=ON
-      #     tags: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}:ci_testing
 
   build-dagmc_test-img:
     needs: [build-dependency-img]
@@ -132,26 +114,8 @@ jobs:
           dockerfile: CI/Dockerfile
           build-args: OWNER=${{ github.repository_owner }}, TAG=ci_testing, UBUNTU_VERSION=${{ matrix.ubuntu_versions }}, COMPILER=${{ matrix.compiler }}, HDF5=${{ matrix.hdf5_versions }}, MOAB=${{ matrix.moab_versions }}, build_mw_reg_tests=ON
 
-      # - name: Test DAGMC in Docker image
-      #   uses: docker/build-push-action@v3
-      #   with:
-      #     file: CI/Dockerfile
-      #     target: dagmc_test
-      #     context: .
-      #     push: false
-      #     build-args: |
-      #       OWNER=${{ github.repository_owner }}
-      #       TAG=ci_testing
-      #       UBUNTU_VERSION=${{ matrix.ubuntu_versions }}
-      #       COMPILER=${{ matrix.compiler }}
-      #       HDF5=${{ matrix.hdf5_versions }}
-      #       MOAB=${{ matrix.moab_versions }}
-      #       build_mw_reg_tests=ON
-      #       dependency_image_location=ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}:ci_testing
-      #     tags: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}-dagmc-test:ci_testing
-
       - name: Log in to the Container registry
-        #if: ${{ github.repository_owner == 'svalinn' }}
+        if: ${{ github.repository_owner == 'svalinn' }}
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
@@ -159,7 +123,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push Image as stable img
-        #if: ${{ github.repository_owner == 'svalinn' }}
+        if: ${{ github.repository_owner == 'svalinn' }}
         uses: akhilerm/tag-push-action@v2.1.0
         with:
           src: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}/dagmc:refs_heads_${{ github.ref_name }}-bk0

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v3
 
 
-      - name: Multistage Docker Build
+      - name: Installing Dependencies in Docker image
         uses: firehed/multistage-docker-build-action@v1
         with:
           repository: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}
@@ -121,7 +121,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Multistage Docker Build
+      - name: Test DAGMC in Docker image
         uses: firehed/multistage-docker-build-action@v1
         with:
           repository: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}
@@ -151,7 +151,7 @@ jobs:
       #     tags: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}-dagmc-test:ci_testing
 
       - name: Log in to the Container registry
-        if: ${{ github.repository_owner == 'svalinn' }}
+        #if: ${{ github.repository_owner == 'svalinn' }}
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
@@ -159,15 +159,15 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push Image as stable img
-        if: ${{ github.repository_owner == 'svalinn' }}
+        #if: ${{ github.repository_owner == 'svalinn' }}
         uses: akhilerm/tag-push-action@v2.1.0
         with:
-          src: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}:ci_testing
+          src: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}/dagmc:refs_heads_${{ github.ref_name }}-bk0
           dst: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}:stable
 
       - name: Push Image as latest img
         if: ${{ github.repository_owner == 'svalinn' }}
         uses: akhilerm/tag-push-action@v2.1.0
         with:
-          src: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}:ci_testing
+          src: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}/dagmc:refs_heads_${{ github.ref_name }}-bk0
           dst: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}:latest

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -50,22 +50,34 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Installing Dependencies in Docker image
-        uses: docker/build-push-action@v3
+
+      - name: Multistage Docker Build
+        uses: firehed/multistage-docker-build-action@v1
         with:
-          file: CI/Dockerfile
-          target: moab
-          context: .
-          push: true
-          build-args: |
-            OWNER=${{ github.repository_owner }}
-            TAG=ci_testing
-            UBUNTU_VERSION=${{ matrix.ubuntu_versions }}
-            COMPILER=${{ matrix.compiler }}
-            HDF5=${{ matrix.hdf5_versions }}
-            MOAB=${{ matrix.moab_versions }}
-            build_mw_reg_tests=ON
-          tags: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}:ci_testing
+          repository: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}
+          stages: base, external_deps, hdf5
+          server-stage: moab
+          quiet: false
+          tag-latest-on-default: false
+          dockerfile: CI/Dockerfile
+          build-args: OWNER=${{ github.repository_owner }}, TAG=ci_testing, UBUNTU_VERSION=${{ matrix.ubuntu_versions }}, COMPILER=${{ matrix.compiler }}, HDF5=${{ matrix.hdf5_versions }}, MOAB=${{ matrix.moab_versions }}, build_mw_reg_tests=ON
+        
+      # - name: Installing Dependencies in Docker image
+      #   uses: docker/build-push-action@v3
+      #   with:
+      #     file: CI/Dockerfile
+      #     target: moab
+      #     context: .
+      #     push: true
+      #     build-args: |
+      #       OWNER=${{ github.repository_owner }}
+      #       TAG=ci_testing
+      #       UBUNTU_VERSION=${{ matrix.ubuntu_versions }}
+      #       COMPILER=${{ matrix.compiler }}
+      #       HDF5=${{ matrix.hdf5_versions }}
+      #       MOAB=${{ matrix.moab_versions }}
+      #       build_mw_reg_tests=ON
+      #     tags: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}:ci_testing
 
   build-dagmc_test-img:
     needs: [build-dependency-img]
@@ -109,23 +121,34 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Test DAGMC in Docker image
-        uses: docker/build-push-action@v3
+      - name: Multistage Docker Build
+        uses: firehed/multistage-docker-build-action@v1
         with:
-          file: CI/Dockerfile
-          target: dagmc_test
-          context: .
-          push: false
-          build-args: |
-            OWNER=${{ github.repository_owner }}
-            TAG=ci_testing
-            UBUNTU_VERSION=${{ matrix.ubuntu_versions }}
-            COMPILER=${{ matrix.compiler }}
-            HDF5=${{ matrix.hdf5_versions }}
-            MOAB=${{ matrix.moab_versions }}
-            build_mw_reg_tests=ON
-            dependency_image_location=ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}:ci_testing
-          tags: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}-dagmc-test:ci_testing
+          repository: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}
+          stages: base, external_deps, hdf5, moab, dagmc
+          server-stage: dagmc_test
+          quiet: false
+          tag-latest-on-default: false
+          dockerfile: CI/Dockerfile
+          build-args: OWNER=${{ github.repository_owner }}, TAG=ci_testing, UBUNTU_VERSION=${{ matrix.ubuntu_versions }}, COMPILER=${{ matrix.compiler }}, HDF5=${{ matrix.hdf5_versions }}, MOAB=${{ matrix.moab_versions }}, build_mw_reg_tests=ON
+
+      # - name: Test DAGMC in Docker image
+      #   uses: docker/build-push-action@v3
+      #   with:
+      #     file: CI/Dockerfile
+      #     target: dagmc_test
+      #     context: .
+      #     push: false
+      #     build-args: |
+      #       OWNER=${{ github.repository_owner }}
+      #       TAG=ci_testing
+      #       UBUNTU_VERSION=${{ matrix.ubuntu_versions }}
+      #       COMPILER=${{ matrix.compiler }}
+      #       HDF5=${{ matrix.hdf5_versions }}
+      #       MOAB=${{ matrix.moab_versions }}
+      #       build_mw_reg_tests=ON
+      #       dependency_image_location=ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}:ci_testing
+      #     tags: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}-dagmc-test:ci_testing
 
       - name: Log in to the Container registry
         if: ${{ github.repository_owner == 'svalinn' }}


### PR DESCRIPTION
## Description
I replaced the `docker/build-push-action` with `firehed/multistage-docker-build-action` and also updated the names for the `src` images in the `akhilerm/tag-push-action` to match the image names that are produced by the multistage action. This is an addition to [this PR](https://github.com/svalinn/DAGMC/pull/863).

## Motivation and Context
The multistage action includes caching of images of intermediate stages and pulling those images from the cache if nothing has changed in those stages of the dockerfile. It is overall more simple and efficient to use. 

## Changes
Replaces `docker/build-push-action` with a multistage build action. 

## Other Information
Currently, the images that are being pushed by the `akhilerm/tag-push-action` are the ones at the `dagmc` stage. Let me know if this is the correct stage for the final images.

I commented out the if statements of the first `akhilerm/tag-push-action` to see if it could find the images built by the multistage action and if it would push an image with the correct tag. This [workflow](https://github.com/bquan0/DAGMC/actions/runs/4749104856/jobs/8436036220) shows that the images can be found and this [package](https://github.com/bquan0/DAGMC/pkgs/container/dagmc-ci-ubuntu-18.04-clang-ext-hdf5_1.10.4-moab_master) shows that the image is being tagged correctly. 

I ran into this `permission_denied: write_package` error a few times in the workflows, and it occurs when the workflow is trying to push an image to ghcr.io. I fixed this by going into the package's settings and checking the DAGMC repo under the "Manage Actions access" section. This is a tedious fix, but I'm not sure if there's another solution. It might have to do with the DAGMC repo not allowing workflows to have "Read and Write permissions" since that option was not enabled when I first cloned the DAGMC repo. 