### PR TITLE
Single dockerfile parallel ci

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -17,7 +17,6 @@ jobs:
     strategy:
       matrix:
         ubuntu_versions : [
-          18.04,
           20.04,
           ]
         compiler : [
@@ -64,7 +63,6 @@ jobs:
     strategy:
       matrix:
         ubuntu_versions : [
-          18.04,
           20.04,
           ]
         compiler : [
@@ -111,7 +109,6 @@ jobs:
     strategy:
       matrix:
         ubuntu_versions : [
-          18.04,
           20.04,
           ]
         compiler : [

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -50,6 +50,7 @@ jobs:
           stages: base, external_deps, hdf5
           server-stage: moab
           quiet: false
+          parallel: true
           tag-latest-on-default: false
           dockerfile: CI/Dockerfile
           build-args: UBUNTU_VERSION=${{ matrix.ubuntu_versions }}, HDF5=${{ matrix.hdf5_versions }}, MOAB=${{ matrix.moab_versions }}
@@ -96,10 +97,15 @@ jobs:
           stages: dagmc
           server-stage: dagmc_test
           quiet: false
+          parallel: true
           tag-latest-on-default: false
           dockerfile: CI/Dockerfile
           build-args: UBUNTU_VERSION=${{ matrix.ubuntu_versions }}, HDF5=${{ matrix.hdf5_versions }}, MOAB=${{ matrix.moab_versions }}
 
+  push_stable_ci_img:
+    needs: [build-dagmc_test-img]
+    runs-on: ubuntu-latest
+    
       - name: Log in to the Container registry
         if: ${{ github.repository_owner == 'svalinn' }}
         uses: docker/login-action@v2

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -105,7 +105,28 @@ jobs:
   push_stable_ci_img:
     needs: [build-dagmc_test-img]
     runs-on: ubuntu-latest
-    
+    env:
+      hdf5_build_dir: hdf5_build_dir
+
+    strategy:
+      matrix:
+        ubuntu_versions : [
+          18.04,
+          20.04,
+          ]
+        compiler : [
+          gcc,
+          clang,
+          ]
+        hdf5_versions : [
+         1.10.4,
+        ]
+        moab_versions : [
+         5.3.0,
+        ]
+
+    name: Pushing final images
+    steps:       
       - name: Log in to the Container registry
         if: ${{ github.repository_owner == 'svalinn' }}
         uses: docker/login-action@v2

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         ubuntu_versions : [
           20.04,
+          22.04,
           ]
         compiler : [
           gcc,
@@ -64,6 +65,7 @@ jobs:
       matrix:
         ubuntu_versions : [
           20.04,
+          22.04,
           ]
         compiler : [
           gcc,
@@ -110,6 +112,7 @@ jobs:
       matrix:
         ubuntu_versions : [
           20.04,
+          22.04,
           ]
         compiler : [
           gcc,

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -53,7 +53,7 @@ jobs:
           parallel: true
           tag-latest-on-default: false
           dockerfile: CI/Dockerfile
-          build-args: UBUNTU_VERSION=${{ matrix.ubuntu_versions }}, HDF5=${{ matrix.hdf5_versions }}, MOAB=${{ matrix.moab_versions }}
+          build-args: COMPILER=${{ matrix.compiler }}, UBUNTU_VERSION=${{ matrix.ubuntu_versions }}, HDF5=${{ matrix.hdf5_versions }}, MOAB=${{ matrix.moab_versions }}
 
   build-dagmc_test-img:
     needs: [build-dependency-img]
@@ -100,7 +100,7 @@ jobs:
           parallel: true
           tag-latest-on-default: false
           dockerfile: CI/Dockerfile
-          build-args: UBUNTU_VERSION=${{ matrix.ubuntu_versions }}, HDF5=${{ matrix.hdf5_versions }}, MOAB=${{ matrix.moab_versions }}
+          build-args: COMPILER=${{ matrix.compiler }}, UBUNTU_VERSION=${{ matrix.ubuntu_versions }}, HDF5=${{ matrix.hdf5_versions }}, MOAB=${{ matrix.moab_versions }}
 
   push_stable_ci_img:
     needs: [build-dagmc_test-img]

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -92,7 +92,7 @@ jobs:
         uses: firehed/multistage-docker-build-action@v1
         with:
           repository: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}
-          stages: dagmc
+          stages: moab, dagmc
           server-stage: dagmc_test
           quiet: false
           parallel: true

--- a/CI/Dockerfile
+++ b/CI/Dockerfile
@@ -9,7 +9,7 @@ ARG geant4_version=10.7.4
 ARG UBUNTU_VERSION=18.04
 ARG MOAB_BRANCH=5.3.0
 ARG double_down=OFF
-ARG ci_jobs=20
+ARG ci_jobs=4
 ARG HDF5_VERSION=1.10.4
 # currently HDF5 major version must be manually set to match HDF5 version
 ARG HDF5_VERSION_major=1.10
@@ -17,12 +17,7 @@ ARG HDF5_VERSION_major=1.10
 ARG build_dir=/root/build_dir
 ARG install_dir=/root/opt
 
-# clang and gcc are options for the compiler but to use them CC and CXX must be set
-# if clang then change cc to clang and cxx to clang++
-# if gcc then change cc to gcc and cxx to g++
-ARG CC=gcc
-ARG CXX=g++
-
+ARG COMPILER=gcc
 
 FROM ubuntu:${UBUNTU_VERSION} AS base
 
@@ -65,8 +60,17 @@ ARG install_dir
 ENV build_dir=${build_dir}
 ENV install_dir=${install_dir}
 
+FROM base as compiler-gcc
 
-FROM base as external_deps
+ENV CC=gcc
+ENV CXX=g++
+
+FROM base as compiler-clang
+
+ENV CC=clang
+ENV CXX=clang++
+
+FROM compiler-${COMPILER} as external_deps
 
 # accessing gloabl ARGs in build stage
 ARG geant4_version


### PR DESCRIPTION
## Description
Some final cleanup and addressing some corner case issues.

## Motivation and Context
With a major push to simplify the building of CI images, this PR into another branch should cleanup the final pieces and move this forward robustly.

## Changes
1. abandon Ubuntu 18.04 and add Ubuntu 22.04 - necessary for new Geant4 10.7.x support
2. pass in compiler choice using multistage docker builds
3. add `moab` stage in multistage build action for `dagmc` to take advantage of cache
4. define a new job for the final push of working images
